### PR TITLE
Added icons to sensors and a small readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ your Toon thermostat and sensors for power and gas consumption..
 Install the files
 ===
 
-On your Home Assistant instance, go to \<config directory\>/custom_components. Create a folder named
-climate and a folder named sensor, if they don't already exist. Now copy the files:
+On your Home Assistant instance, go to \<config directory\>/custom_components. Create folders named
+sensor, climate and switch, if they don't already exist. Now copy the files:
 ```
 toon.py ---> <config directory>/custom_components
-Sensor/toon.py ---> <config directory>/custom_components/sensor
-Climate/toon.py ---> <config directory>/custom_components/climate
+sensor/toon.py ---> <config directory>/custom_components/sensor
+climate/toon.py ---> <config directory>/custom_components/climate
+switch/toon.py ---> <config directory>/custom_components/switch
 ```
 Configuration
 ===

--- a/sensor/toon.py
+++ b/sensor/toon.py
@@ -20,33 +20,35 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     _toon_main = hass.data[toon_main.TOON_HANDLE]
 
     sensor_items = []
-    sensor_items.extend([ToonSensor(hass, 'Power_current', 'Watt'),
-                        ToonSensor(hass, 'Power_today', 'kWh')])
+    sensor_items.extend([ToonSensor(hass, 'Power_current', 'power-plug', 'Watt'),
+                        ToonSensor(hass, 'Power_today', 'power-plug', 'kWh')])
 
     if _toon_main.gas:
-        sensor_items.extend([ToonSensor(hass, 'Gas_current', 'CM3'),
-                            ToonSensor(hass, 'Gas_today', 'M3')])
+        sensor_items.extend([ToonSensor(hass, 'Gas_current', 'gas-cylinder', 'CM3'),
+                            ToonSensor(hass, 'Gas_today', 'gas-cylinder', 'M3')])
 
     for plug in _toon_main.toon.smartplugs:
         sensor_items.extend([
             FibaroSensor(hass,
                          '{}_current_power'.format(plug.name),
                          plug.name,
+                         'power-socket-eu',
                          'Watt'),
             FibaroSensor(hass,
                          '{}_today_energy'.format(plug.name),
                          plug.name,
+                         'power-socket-eu',
                          'kWh')])
 
     if _toon_main.toon.solar.produced or _toon_main.solar:
         sensor_items.extend([
-            SolarSensor(hass, 'Solar_maximum', 'kWh'),
-            SolarSensor(hass, 'Solar_produced', 'kWh'),
-            SolarSensor(hass, 'Solar_value', 'Watt'),
-            SolarSensor(hass, 'Solar_average_produced', 'kWh'),
-            SolarSensor(hass, 'Solar_meter_reading_low_produced', 'kWh'),
-            SolarSensor(hass, 'Solar_meter_reading_produced', 'kWh'),
-            SolarSensor(hass, 'Solar_daily_cost_produced', 'Euro')
+            SolarSensor(hass, 'Solar_maximum', 'weather-sunny', 'kWh'),
+            SolarSensor(hass, 'Solar_produced', 'weather-sunny', 'kWh'),
+            SolarSensor(hass, 'Solar_value', 'weather-sunny', 'Watt'),
+            SolarSensor(hass, 'Solar_average_produced', 'weather-sunny', 'kWh'),
+            SolarSensor(hass, 'Solar_meter_reading_low_produced', 'weather-sunny', 'kWh'),
+            SolarSensor(hass, 'Solar_meter_reading_produced', 'weather-sunny', 'kWh'),
+            SolarSensor(hass, 'Solar_daily_cost_produced', 'weather-sunny', 'Euro')
         ])
 
     for smokedetector in _toon_main.toon.smokedetectors:
@@ -54,6 +56,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             FibaroSmokeDetector(hass,
                                 '{}_smoke_detector'.format(smokedetector.name),
                                 smokedetector.device_uuid,
+                                'alarm-bell',
                                 '%'))
 
     add_devices(sensor_items)
@@ -62,10 +65,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class ToonSensor(Entity):
     """Representation of a sensor."""
 
-    def __init__(self, hass, name, unit_of_measurement):
+    def __init__(self, hass, name, icon, unit_of_measurement):
         """Initialize the sensor."""
         self._name = name
         self._state = None
+        self._icon = "mdi:" + icon
         self._unit_of_measurement = unit_of_measurement
         self.thermos = hass.data[toon_main.TOON_HANDLE]
 
@@ -78,6 +82,11 @@ class ToonSensor(Entity):
     def name(self):
         """Return the name of the sensor."""
         return self._name
+
+    @property
+    def icon(self):
+        """Return the mdi icon of the sensor."""
+        return self._icon
 
     @property
     def state(self):
@@ -97,11 +106,12 @@ class ToonSensor(Entity):
 class FibaroSensor(Entity):
     """Representation of a sensor."""
 
-    def __init__(self, hass, name, plug_name, unit_of_measurement):
+    def __init__(self, hass, name, plug_name, icon, unit_of_measurement):
         """Initialize the sensor."""
         self._name = name
         self._plug_name = plug_name
         self._state = None
+        self._icon = "mdi:" + icon
         self._unit_of_measurement = unit_of_measurement
         self.toon = hass.data[toon_main.TOON_HANDLE]
 
@@ -114,6 +124,10 @@ class FibaroSensor(Entity):
     def name(self):
         """Return the name of the sensor."""
         return self._name
+    @property
+    def icon(self):
+        """Return the mdi icon of the sensor."""
+        return self._icon
 
     @property
     def state(self):
@@ -134,10 +148,11 @@ class FibaroSensor(Entity):
 class SolarSensor(Entity):
     """Representation of a sensor."""
 
-    def __init__(self, hass, name, unit_of_measurement):
+    def __init__(self, hass, name, icon, unit_of_measurement):
         """Initialize the sensor."""
         self._name = name
         self._state = None
+        self._icon = "mdi:" + icon
         self._unit_of_measurement = unit_of_measurement
         self.toon = hass.data[toon_main.TOON_HANDLE]
 
@@ -150,6 +165,11 @@ class SolarSensor(Entity):
     def name(self):
         """Return the name of the sensor."""
         return self._name
+
+    @property
+    def icon(self):
+        """Return the mdi icon of the sensor."""
+        return self._icon
 
     @property
     def state(self):
@@ -169,11 +189,12 @@ class SolarSensor(Entity):
 class FibaroSmokeDetector(Entity):
     """Representation of a smoke detector."""
 
-    def __init__(self, hass, name, uid, unit_of_measurement):
+    def __init__(self, hass, name, uid, icon, unit_of_measurement):
         """Initialize the sensor."""
         self._name = name
         self._uid = uid
         self._state = None
+        self._icon = "mdi:" + icon
         self._unit_of_measurement = unit_of_measurement
         self.toon = hass.data[toon_main.TOON_HANDLE]
 
@@ -186,6 +207,11 @@ class FibaroSmokeDetector(Entity):
     def name(self):
         """Return the name of the sensor."""
         return self._name
+
+    @property
+    def icon(self):
+        """Return the mdi icon of the sensor."""
+        return self._icon
 
     @property
     def state_attributes(self):


### PR DESCRIPTION
The icons of the toon sensors were the default `mdi:eye`, instead of something more representable. Added what i thought were the most fitting icons but do change them if you find something better.