### PR TITLE
Merge changes made for hass back into ToonHA

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,3 +11,5 @@ Contributors
 ------------
 
 * Costas Tyfoxylos <costas.tyf@gmail.com>
+
+* Lem Severein <boltgolt@gmail.com>

--- a/binary_sensor/toon.py
+++ b/binary_sensor/toon.py
@@ -1,6 +1,8 @@
 """
-Toon van Eneco burner status.
+Toon van Eneco burner binary sensor.
 
+This provides a sensor for water heater ("burner") activity. The burner can
+either be an actual gas burner or an electric heater.
 """
 import logging
 
@@ -32,7 +34,7 @@ class BurnerSensor(BinarySensorDevice):
 
     @property
     def name(self):
-        """Return the name of the blink sensor."""
+        """Return the name of the sensor."""
         return self._name
 
     @property

--- a/climate/toon.py
+++ b/climate/toon.py
@@ -13,7 +13,7 @@ from homeassistant.components.climate import (ClimateDevice,
                                               STATE_COOL)
 from homeassistant.const import TEMP_CELSIUS
 
-import homeassistant.components.toon as toon_main
+import custom_components.toon as toon_main
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/climate/toon.py
+++ b/climate/toon.py
@@ -1,24 +1,19 @@
 """
 Toon van Eneco Thermostat Support.
+
 This provides a component for the rebranded Quby thermostat as provided by
 Eneco.
 """
 
 from homeassistant.components.climate import (ClimateDevice,
                                               ATTR_TEMPERATURE,
+                                              STATE_PERFORMANCE,
                                               STATE_HEAT,
+                                              STATE_ECO,
                                               STATE_COOL)
-from homeassistant.const import (TEMP_CELSIUS,
-                                 STATE_HOME,
-                                 STATE_NOT_HOME,
-                                 STATE_UNKNOWN)
-import custom_components.toon as toon_main
+from homeassistant.const import TEMP_CELSIUS
 
-STATE_HEAT = 'Comfort'
-STATE_HOME = 'Home'
-STATE_NOT_HOME = 'Away'
-STATE_COOL = 'Sleep'
-STATE_UNKNOWN = 'Manual'
+import homeassistant.components.toon as toon_main
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -40,8 +35,10 @@ class ThermostatDevice(ClimateDevice):
         self._state = None
         self._temperature = None
         self._setpoint = None
-        self._operation_list = [STATE_HEAT, STATE_HOME, STATE_NOT_HOME,
-                                STATE_COOL, STATE_UNKNOWN]
+        self._operation_list = [STATE_PERFORMANCE,
+                                STATE_HEAT,
+                                STATE_ECO,
+                                STATE_COOL]
 
     @property
     def name(self):
@@ -85,8 +82,13 @@ class ThermostatDevice(ClimateDevice):
         self.thermos.set_temp(temp)
 
     def set_operation_mode(self, operation_mode):
-        """Set new operation mode."""
-        self.thermos.set_state(operation_mode)
+        """Set new operation mode as toonlib requires it."""
+        toonlib_values = {STATE_PERFORMANCE: 'Comfort',
+                          STATE_HEAT: 'Home',
+                          STATE_ECO: 'Away',
+                          STATE_COOL: 'Sleep'}
+
+        self.thermos.set_state(toonlib_values[operation_mode])
 
     def update(self):
         """Update local state."""

--- a/sensor/toon.py
+++ b/sensor/toon.py
@@ -8,7 +8,7 @@ import logging
 import datetime as datetime
 
 from homeassistant.helpers.entity import Entity
-import homeassistant.components.toon as toon_main
+import custom_components.toon as toon_main
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/sensor/toon.py
+++ b/sensor/toon.py
@@ -1,13 +1,14 @@
 """
 Toon van Eneco Utility Gages.
+
 This provides a component for the rebranded Quby thermostat as provided by
 Eneco.
 """
 import logging
+import datetime as datetime
 
 from homeassistant.helpers.entity import Entity
-import custom_components.toon as toon_main
-import datetime as datetime
+import homeassistant.components.toon as toon_main
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -20,12 +21,24 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     _toon_main = hass.data[toon_main.TOON_HANDLE]
 
     sensor_items = []
-    sensor_items.extend([ToonSensor(hass, 'Power_current', 'power-plug', 'Watt'),
-                        ToonSensor(hass, 'Power_today', 'power-plug', 'kWh')])
+    sensor_items.extend([ToonSensor(hass,
+                                    'Power_current',
+                                    'power-plug',
+                                    'Watt'),
+                         ToonSensor(hass,
+                                    'Power_today',
+                                    'power-plug',
+                                    'kWh')])
 
     if _toon_main.gas:
-        sensor_items.extend([ToonSensor(hass, 'Gas_current', 'gas-cylinder', 'CM3'),
-                            ToonSensor(hass, 'Gas_today', 'gas-cylinder', 'M3')])
+        sensor_items.extend([ToonSensor(hass,
+                                        'Gas_current',
+                                        'gas-cylinder',
+                                        'CM3'),
+                             ToonSensor(hass,
+                                        'Gas_today',
+                                        'gas-cylinder',
+                                        'M3')])
 
     for plug in _toon_main.toon.smartplugs:
         sensor_items.extend([
@@ -42,13 +55,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     if _toon_main.toon.solar.produced or _toon_main.solar:
         sensor_items.extend([
-            SolarSensor(hass, 'Solar_maximum', 'weather-sunny', 'kWh'),
-            SolarSensor(hass, 'Solar_produced', 'weather-sunny', 'kWh'),
-            SolarSensor(hass, 'Solar_value', 'weather-sunny', 'Watt'),
-            SolarSensor(hass, 'Solar_average_produced', 'weather-sunny', 'kWh'),
-            SolarSensor(hass, 'Solar_meter_reading_low_produced', 'weather-sunny', 'kWh'),
-            SolarSensor(hass, 'Solar_meter_reading_produced', 'weather-sunny', 'kWh'),
-            SolarSensor(hass, 'Solar_daily_cost_produced', 'weather-sunny', 'Euro')
+            SolarSensor(hass, 'Solar_maximum', 'kWh'),
+            SolarSensor(hass, 'Solar_produced', 'kWh'),
+            SolarSensor(hass, 'Solar_value', 'Watt'),
+            SolarSensor(hass, 'Solar_average_produced', 'kWh'),
+            SolarSensor(hass, 'Solar_meter_reading_low_produced', 'kWh'),
+            SolarSensor(hass, 'Solar_meter_reading_produced', 'kWh'),
+            SolarSensor(hass, 'Solar_daily_cost_produced', 'Euro')
         ])
 
     for smokedetector in _toon_main.toon.smokedetectors:
@@ -75,7 +88,7 @@ class ToonSensor(Entity):
 
     @property
     def should_poll(self):
-        """Polling required"""
+        """Polling required."""
         return True
 
     @property
@@ -117,13 +130,14 @@ class FibaroSensor(Entity):
 
     @property
     def should_poll(self):
-        """Polling required"""
+        """Polling required."""
         return True
 
     @property
     def name(self):
         """Return the name of the sensor."""
         return self._name
+
     @property
     def icon(self):
         """Return the mdi icon of the sensor."""
@@ -148,17 +162,17 @@ class FibaroSensor(Entity):
 class SolarSensor(Entity):
     """Representation of a sensor."""
 
-    def __init__(self, hass, name, icon, unit_of_measurement):
+    def __init__(self, hass, name, unit_of_measurement):
         """Initialize the sensor."""
         self._name = name
         self._state = None
-        self._icon = "mdi:" + icon
+        self._icon = "mdi:weather-sunny"
         self._unit_of_measurement = unit_of_measurement
         self.toon = hass.data[toon_main.TOON_HANDLE]
 
     @property
     def should_poll(self):
-        """Polling required"""
+        """Polling required."""
         return True
 
     @property
@@ -200,7 +214,7 @@ class FibaroSmokeDetector(Entity):
 
     @property
     def should_poll(self):
-        """Polling required"""
+        """Polling required."""
         return True
 
     @property
@@ -217,8 +231,8 @@ class FibaroSmokeDetector(Entity):
     def state_attributes(self):
         """Return the state attributes of the smoke detectors."""
         value = datetime.datetime.fromtimestamp(
-                    int(self.toon.get_data('last_connected_change', self.name))
-                ).strftime('%Y-%m-%d %H:%M:%S')
+            int(self.toon.get_data('last_connected_change', self.name))
+        ).strftime('%Y-%m-%d %H:%M:%S')
 
         return {
             STATE_ATTR_DEVICE_TYPE: self.toon.get_data('device_type',

--- a/sensor/toon.py
+++ b/sensor/toon.py
@@ -42,16 +42,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     for plug in _toon_main.toon.smartplugs:
         sensor_items.extend([
-            FibaroSensor(hass,
-                         '{}_current_power'.format(plug.name),
-                         plug.name,
-                         'power-socket-eu',
-                         'Watt'),
-            FibaroSensor(hass,
-                         '{}_today_energy'.format(plug.name),
-                         plug.name,
-                         'power-socket-eu',
-                         'kWh')])
+            SmartPlug(hass,
+                      '{}_current_power'.format(plug.name),
+                      plug.name,
+                      'power-socket-eu',
+                      'Watt'),
+            SmartPlug(hass,
+                      '{}_today_energy'.format(plug.name),
+                      plug.name,
+                      'power-socket-eu',
+                      'kWh')])
 
     if _toon_main.toon.solar.produced or _toon_main.solar:
         sensor_items.extend([
@@ -66,11 +66,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     for smokedetector in _toon_main.toon.smokedetectors:
         sensor_items.append(
-            FibaroSmokeDetector(hass,
-                                '{}_smoke_detector'.format(smokedetector.name),
-                                smokedetector.device_uuid,
-                                'alarm-bell',
-                                '%'))
+            SmokeDetector(hass,
+                          '{}_smoke_detector'.format(smokedetector.name),
+                          smokedetector.device_uuid,
+                          'alarm-bell',
+                          '%'))
 
     add_devices(sensor_items)
 
@@ -116,7 +116,7 @@ class ToonSensor(Entity):
         self.thermos.update()
 
 
-class FibaroSensor(Entity):
+class SmartPlug(Entity):
     """Representation of a sensor."""
 
     def __init__(self, hass, name, plug_name, icon, unit_of_measurement):
@@ -200,7 +200,7 @@ class SolarSensor(Entity):
         self.toon.update()
 
 
-class FibaroSmokeDetector(Entity):
+class SmokeDetector(Entity):
     """Representation of a smoke detector."""
 
     def __init__(self, hass, name, uid, icon, unit_of_measurement):

--- a/switch/toon.py
+++ b/switch/toon.py
@@ -1,7 +1,7 @@
 """
 Support for Eneco Slimmer stekkers (Smart Plugs).
 
-This provides controlls for the z-wave smart plugs Toon can control.
+This provides controls for the z-wave smart plugs Toon can control.
 """
 import logging
 

--- a/switch/toon.py
+++ b/switch/toon.py
@@ -1,11 +1,12 @@
 """
 Support for Eneco Slimmer stekkers (Smart Plugs).
 
+This provides controlls for the z-wave smart plugs Toon can control.
 """
 import logging
 
 from homeassistant.components.switch import SwitchDevice
-import custom_components.toon as toon_main
+import homeassistant.components.toon as toon_main
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/switch/toon.py
+++ b/switch/toon.py
@@ -6,7 +6,7 @@ This provides controlls for the z-wave smart plugs Toon can control.
 import logging
 
 from homeassistant.components.switch import SwitchDevice
-import homeassistant.components.toon as toon_main
+import custom_components.toon as toon_main
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/toon.py
+++ b/toon.py
@@ -15,7 +15,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
 # Home Assistant depends on 3rd party packages for API specific code.
-REQUIREMENTS = ['toonlib==1.0.2']
+REQUIREMENTS = ['toonlib==1.1.2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,7 +54,7 @@ def setup(hass, config):
         return False
 
     # Load all platforms
-    for platform in ('climate', 'sensor', 'switch'):
+    for platform in ('binary_sensor', 'climate', 'sensor', 'switch'):
         load_platform(hass, platform, DOMAIN, {}, config)
 
     # Initialization successfull
@@ -91,6 +91,7 @@ class ToonDataStore:
             (float(self.toon.power.daily_usage) +
              float(self.toon.power.daily_usage_low)) / 1000, 2)
         self.data['temp'] = self.toon.temperature
+        self.data['burner_on'] = self.toon.burner_on
 
         if self.toon.thermostat_state:
             self.data['state'] = self.toon.thermostat_state.name

--- a/toon.py
+++ b/toon.py
@@ -1,20 +1,25 @@
 """
 Toon van Eneco Support.
+
 This provides a component for the rebranded Quby thermostat as provided by
 Eneco.
 """
 import logging
+from datetime import datetime, timedelta
 import voluptuous as vol
 
 # Import the device class from the component that you want to support
 from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD)
 from homeassistant.helpers.discovery import load_platform
 import homeassistant.helpers.config_validation as cv
+from homeassistant.util import Throttle
 
 # Home Assistant depends on 3rd party packages for API specific code.
-REQUIREMENTS = ['toonlib==1.1.2']
+REQUIREMENTS = ['toonlib==1.0.2']
 
 _LOGGER = logging.getLogger(__name__)
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=5)
 
 DOMAIN = 'toon'
 TOON_HANDLE = 'toon_handle'
@@ -48,18 +53,9 @@ def setup(hass, config):
     except InvalidCredentials:
         return False
 
-    if hass.data[TOON_HANDLE]:
-        # Load binary_sensor (for Burner)
-        load_platform(hass, 'binary_sensor', DOMAIN)
-
-        # Load climate (for Thermostat)
-        load_platform(hass, 'climate', DOMAIN)
-
-        # Load sensor (for Gas and Power, Solar and Smoke Detectors)
-        load_platform(hass, 'sensor', DOMAIN)
-
-        # Load switch (for Slimme Stekkers)
-        load_platform(hass, 'switch', DOMAIN)
+    # Load all platforms
+    for platform in ('climate', 'sensor', 'switch'):
+        load_platform(hass, platform, DOMAIN, {}, config)
 
     # Initialization successfull
     return True
@@ -82,16 +78,19 @@ class ToonDataStore:
         self.solar = solar
         self.data = {}
 
+        self.last_update = datetime.min
         self.update()
 
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Update toon data."""
+        self.last_update = datetime.now()
+
         self.data['power_current'] = self.toon.power.value
         self.data['power_today'] = round(
             (float(self.toon.power.daily_usage) +
              float(self.toon.power.daily_usage_low)) / 1000, 2)
         self.data['temp'] = self.toon.temperature
-        self.data['burner_on'] = self.toon.burner_on
 
         if self.toon.thermostat_state:
             self.data['state'] = self.toon.thermostat_state.name
@@ -110,6 +109,7 @@ class ToonDataStore:
                                         float(plug.daily_usage) / 1000, 2),
                                     'current_state': plug.current_state,
                                     'is_connected': plug.is_connected}
+
         self.data['solar_maximum'] = self.toon.solar.maximum
         self.data['solar_produced'] = self.toon.solar.produced
         self.data['solar_value'] = self.toon.solar.value
@@ -120,21 +120,22 @@ class ToonDataStore:
             self.toon.solar.meter_reading_produced
         self.data['solar_daily_cost_produced'] = \
             self.toon.solar.daily_cost_produced
-        for sd in self.toon.smokedetectors:
-            value = '{}_smoke_detector'.format(sd.name)
-            self.data[value] = {'smoke_detector': sd.battery_level,
-                                'device_type': sd.device_type,
-                                'is_connected': sd.is_connected,
+
+        for detector in self.toon.smokedetectors:
+            value = '{}_smoke_detector'.format(detector.name)
+            self.data[value] = {'smoke_detector': detector.battery_level,
+                                'device_type': detector.device_type,
+                                'is_connected': detector.is_connected,
                                 'last_connected_change':
-                                sd.last_connected_change}
+                                detector.last_connected_change}
 
     def set_state(self, state):
+        """Push a new state to the Toon unit."""
         self.toon.thermostat_state = state
-        self.update()
 
     def set_temp(self, temp):
+        """Push a new temperature to the Toon unit."""
         self.toon.thermostat = temp
-        self.update()
 
     def get_data(self, data_id, plug_name=None):
         """Get the cached data."""


### PR DESCRIPTION
As [this](https://github.com/krocat/ToonHA/tree/6c382986974a9adde0d6ea53dd607ece4ae8027a) version of ToonHA has finally been added into the main hass repo it's time to merge the changes requested by the hass team back into ToonHA. I've modified the changes so it fits into ToonHA as a custom component. (looks like i can't push to new branches so this is a PR instead of a MR)

@costastf could you elaborate what you meant with removing the fibaro part?