### PR TITLE
Added warnings for credential errors

### DIFF
--- a/toon.py
+++ b/toon.py
@@ -58,11 +58,15 @@ def setup(hass, config):
                                                config['toon'][CONF_SECRET],
                                                gas,
                                                solar)
+
     except InvalidCredentials:
+        _LOGGER.warning("The credentials in your config are invalid")
         return False
     except InvalidConsumerKey:
+        _LOGGER.warning("Your customer key is invalid")
         return False
     except InvalidConsumerSecret:
+        _LOGGER.warning("Your customer secret is invalid")
         return False
 
     # Load all platforms


### PR DESCRIPTION
Issue #23 made it clear that a credential error was extremely unclear and would just result in an"component could not be set up" message. This pull request will add warnings indicating what's wrong.