### PR TITLE
google assistant temperature setting fix 2

### DIFF
--- a/climate/toon.py
+++ b/climate/toon.py
@@ -36,13 +36,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     # Add toon
     add_devices((ThermostatDevice(hass), ), True)
 
-
 class ThermostatDevice(ClimateDevice):
     """Interface class for the toon module and HA."""
 
     def __init__(self, hass):
         """Initialize the device."""
-        self._name = 'Toon'
+        self._name = 'Toon van Eneco'
         self.hass = hass
         self.thermos = hass.data[toon_main.TOON_HANDLE]
 
@@ -61,16 +60,6 @@ class ThermostatDevice(ClimateDevice):
     def supported_features(self):
         """Return the list of supported features."""
         return SUPPORT_FLAGS
-        
-    @property
-    def min_temp(self):
-        """Return the minimum temperature."""
-        return 13
-
-    @property
-    def max_temp(self):
-        """Return the maximum temperature."""
-        return 23
                                    
     @property
     def name(self):
@@ -81,11 +70,6 @@ class ThermostatDevice(ClimateDevice):
     def should_poll(self):
         """Polling is required."""
         return True
-
-    @property
-    def entity_picture(self):
-        """Icon to use in the frontend."""
-        return '/local/toonicon.png'
 
     @property
     def temperature_unit(self):
@@ -108,7 +92,7 @@ class ThermostatDevice(ClimateDevice):
     @property
     def current_temperature(self):
         """Return the current temperature."""
-        return self.thermos.get_data('toon_temperture')
+        return self.thermos.get_data('temp')
 
     @property
     def target_temperature(self):

--- a/climate/toon.py
+++ b/climate/toon.py
@@ -12,6 +12,7 @@ from homeassistant.components.climate import (ClimateDevice,
                                               STATE_HEAT,
                                               STATE_ECO,
                                               STATE_COOL,
+                                              STATE_DRY,
                                               SUPPORT_TARGET_TEMPERATURE,
                                               SUPPORT_OPERATION_MODE)
 from homeassistant.const import TEMP_CELSIUS
@@ -51,6 +52,7 @@ class ThermostatDevice(ClimateDevice):
         self._operation_list = [STATE_AUTO,
                                 STATE_HEAT,
                                 STATE_ECO,
+                                STATE_DRY,
                                 STATE_COOL]
 
     @property
@@ -76,7 +78,10 @@ class ThermostatDevice(ClimateDevice):
     @property
     def current_operation(self):
         """Return current operation i.e. comfort, home, away."""
-        return TOON_HA.get(self.thermos.get_data('state'))
+        if TOON_HA.get(self.thermos.get_data('state')) == None:
+            return STATE_DRY
+        else: 
+            return TOON_HA.get(self.thermos.get_data('state'))
 
     @property
     def operation_list(self):


### PR DESCRIPTION
this will let you use the google assistant to set the temperature for toon.

## just some information

```
#            GOOGLE              |   HOME ASSISTANT      |  TEMPERATURE SETTING | VOICE
# (NO APP)    off                |     STATE_off         |                      | TRUE
# (NO APP)    on                 |     STATE_ON          |                      | FALCE
# (IN APP)    heat               |   STATE_HEAT      X   |   X                  | TRUE
# (IN APP)    cool               |   STATE_COOL      X   |   X                  | TRUE
# (IN APP)    heatcool (auto)    |   STATE_AUTO      X   |   X                  | TRUE
# (NO APP)    fan-only           |   STATE_FAN_ONLY      |   ?                  | TRUE
# (NO APP)    dry                |   STATE_DRY       x   |   X                  | TRUE
# (IN APP)    eco                |   STATE_ECO       X   |   X                  | TRUE
```

there are 4 states that you can use in the google frontend.
there are 4 extra states that you can use in the google backend.

if you want to use the google assistant 'set temperature' function you need to give it an backend state so it does not retrieve an error. because the toon gives state ``null`` if set to custom temperature, google cant handle that.

tested on HA version: 0.87.0

## problems

- this is not tested on latest HA version
- after setting the temperature with the google assistant the state `OFF` is visible in the home assistant frontend
- after setting the temperature manually on the toon display, HA will result in `OFF`
- you can not use the temperture controls in the google home app if the toon is in state ``AUTO, FAN_ONLY, DRY, ECO, OFF`` **this is an google problem**
- if you ask google to set the temperture at 21 C and ``thuis`` == 21 C, HA will result OFF and stay there
- if you set the mode OFF in HA frontend it will return an error because that state is not available.

## note
**it does work!**
## **redy for review**
